### PR TITLE
FOGL-6130 Required files added for its packaging

### DIFF
--- a/Description
+++ b/Description
@@ -1,0 +1,1 @@
+Dispatcher service is responsible for dispatching control messages between Fledge services.

--- a/Package
+++ b/Package
@@ -1,0 +1,26 @@
+# A set of variables that define how we package this repository
+#
+service_name=dispatcher
+exec_name=fledge.services.${service_name}
+
+# Now build up the runtime requirements list. This has 3 components
+#   1. Generic packages we depend on in all architectures and package managers
+#   2. Architecture specific packages we depend on
+#   3. Package manager specific packages we depend on
+requirements="fledge"
+
+case "$arch" in
+        x86_64)
+                ;;
+        armv7l)
+                ;;
+        aarch64)
+                ;;
+esac
+case "$package_manager" in
+        deb)
+            ;;
+        rpm)
+            ;;
+esac
+

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 fledge_version>=1.9
-dispatcher_version=1.9.0
+dispatcher_version=1.9.2


### PR DESCRIPTION
**Package contents**:

```
 $ sudo dpkg -c archive/DEBIAN/x86_64/fledge-service-dispatcher_1.9.2-6_x86_64.deb  
drwxrwxr-x aj/aj             0 2021-12-22 13:10 ./
drwxrwxr-x aj/aj             0 2021-12-22 13:10 ./usr/
drwxrwxr-x aj/aj             0 2021-12-22 13:10 ./usr/local/
drwxrwxr-x aj/aj             0 2021-12-22 13:10 ./usr/local/fledge/
drwxrwxr-x aj/aj             0 2021-12-22 13:10 ./usr/local/fledge/services/
-rwxrwxr-x aj/aj        556688 2021-12-22 13:10 ./usr/local/fledge/services/fledge.services.dispatcher
```

*APT Installation logs*
```
$ sudo apt install -y ./fledge-service-dispatcher_1.9.2-6_x86_64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'fledge-service-dispatcher' instead of './fledge-service-dispatcher_1.9.2-6_x86_64.deb'
The following packages were automatically installed and are no longer required:
  libblas3 libgfortran4 libjbig0 libjpeg-turbo8 libjpeg8 liblapack3 liblcms2-2 libtiff5 libwebp6 libwebpdemux2 libwebpmux3
  linux-aws-5.4-headers-5.4.0-1056 linux-aws-5.4-headers-5.4.0-1057 python3-decorator python3-numpy python3-olefile python3-pil
  python3-scipy
Use 'sudo apt autoremove' to remove them.
The following NEW packages will be installed:
  fledge-service-dispatcher
0 upgraded, 1 newly installed, 0 to remove and 10 not upgraded.
Need to get 0 B/122 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 /home/ubuntu/fledge-service-dispatcher_1.9.2-6_x86_64.deb fledge-service-dispatcher amd64 1.9.2-6-g306f00a [122 kB]
Selecting previously unselected package fledge-service-dispatcher.
(Reading database ... 177212 files and directories currently installed.)
Preparing to unpack .../fledge-service-dispatcher_1.9.2-6_x86_64.deb ...
Unpacking fledge-service-dispatcher (1.9.2-6-g306f00a) ...
Setting up fledge-service-dispatcher (1.9.2-6-g306f00a) ...

```
**Add service**
```
$ curl -sX POST http://localhost:8081/fledge/service -d '{"name": "DispatcherServer", "type": "dispatcher", "enabled": true}' | jq
{
  "name": "DispatcherServer",
  "id": "4eea9a7f-b75c-4095-b564-1cca77a9003e"
}

```
**GET services**
```
http://localhost:8081/fledge/service

{
  "services": [
    {
      "name": "Fledge Storage",
      "type": "Storage",
      "address": "localhost",
      "management_port": 45175,
      "service_port": 41655,
      "protocol": "http",
      "status": "running"
    },
    {
      "name": "Fledge Core",
      "type": "Core",
      "address": "0.0.0.0",
      "management_port": 43469,
      "service_port": 8081,
      "protocol": "http",
      "status": "running"
    },
    {
      "name": "DispatcherServer",
      "type": "Dispatcher",
      "address": "localhost",
      "management_port": 34627,
      "service_port": 38791,
      "protocol": "http",
      "status": "running"
    }
  ]
}
```

```
$ ./scripts/fledge status
Fledge v1.9.2 running.
Fledge Uptime:  215 seconds.
Fledge records: 0 read, 0 sent, 0 purged.
Fledge does not require authentication.
=== Fledge services:
fledge.services.core
fledge.services.storage --address=0.0.0.0 --port=43469
fledge.services.dispatcher --port=43469 --address=127.0.0.1 --name=DispatcherServer 
=== Fledge tasks:

```