### PR TITLE
log level fixes in config change

### DIFF
--- a/C/services/dispatcher/dispatcher_service.cpp
+++ b/C/services/dispatcher/dispatcher_service.cpp
@@ -409,7 +409,7 @@ void DispatcherService::cleanupResources()
 void DispatcherService::configChange(const string& categoryName,
 				       const string& category)
 {
-	m_logger->fatal("Categoty change '%s'", categoryName.c_str());
+	m_logger->debug("Category change '%s'", categoryName.c_str());
 	if (categoryName.compare(m_name) == 0)
 	{
 			m_logger->warn("Configuration change for '%s' category not implemented yet",


### PR DESCRIPTION
On changing the dispatcher category seen some FATAL errors which is actually not. Therefore converted to debug log level.

**OLD**
```
 Fledge dispatcher[21047]: FATAL: Categoty change 'dispatcherAdvanced'
```

With **new change**

```
Fledge dispatcher[25745]: DEBUG: Category change 'dispatcherAdvanced'
```